### PR TITLE
Added authorization to Post endpoints

### DIFF
--- a/Tabloid/Controllers/PostController.cs
+++ b/Tabloid/Controllers/PostController.cs
@@ -4,6 +4,7 @@ using System;
 using Tabloid.Repositories;
 using Tabloid.Models;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Tabloid.Controllers
 {
@@ -19,6 +20,7 @@ namespace Tabloid.Controllers
 
         // https://localhost:5001/api/posts/
         [HttpGet]
+        [Authorize]
         public IActionResult Get()
         {
             try
@@ -34,6 +36,7 @@ namespace Tabloid.Controllers
 
         // https://localhost:5001/api/myposts/ByAuthor/1
         [HttpGet("ByAuthor/{firebaseUserId}")]
+        [Authorize]
         public IActionResult GetPostsByAuthor(string firebaseUserId)
         {
             List<Post> post = _postRepository.GetPostsByAuthor(firebaseUserId);

--- a/Tabloid/appsettings.json
+++ b/Tabloid/appsettings.json
@@ -10,5 +10,5 @@
   "ConnectionStrings": {
     "DefaultConnection": "server=localhost\\SQLExpress;database=Tabloid;integrated security=true;TrustServerCertificate=true;"
   },
-  "FirebaseProjectId": "galloping-galleons"
+  "FirebaseProjectId": "galloping-galleon"
 }


### PR DESCRIPTION
The groundwork for authorization was already in place in Javier's front end code, but the back end endpoint for Posts needed to be updated to actually require a bearer token.